### PR TITLE
Finish Weapon Pickup, Add Swing Timer

### DIFF
--- a/Scenes/Subscenes/sword.tscn
+++ b/Scenes/Subscenes/sword.tscn
@@ -20,8 +20,20 @@ polygon = PackedVector2Array(-8, 8, 0, 8, 8, -4, 8, -8, 4, -8, -8, 0)
 scale = Vector2(2, 2)
 texture = ExtResource("1_2eoit")
 
-[node name="InteractArea" parent="RigidBody2D" instance=ExtResource("2_28sub")]
+[node name="InteractArea" parent="RigidBody2D" node_paths=PackedStringArray("parentObject") instance=ExtResource("2_28sub")]
 script = ExtResource("3_jjcwu")
+parentObject = NodePath("../..")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="RigidBody2D/InteractArea"]
 shape = SubResource("RectangleShape2D_f4t1b")
+
+[node name="pickupLabel" type="Label" parent="RigidBody2D/InteractArea"]
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -71.0
+offset_top = 13.175
+offset_right = 71.0
+offset_bottom = 36.175
+grow_horizontal = 2
+text = "Press [E] to pickup"

--- a/Scenes/controlled1.tscn
+++ b/Scenes/controlled1.tscn
@@ -15,14 +15,14 @@ size = Vector2(32, 32)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_oerxt"]
 size = Vector2(10.525, 18)
 
-
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jjc8b"]
 size = Vector2(32, 32)
 
-[node name="controlled1" type="CharacterBody2D" node_paths=PackedStringArray("playerInteract")]
+[node name="controlled1" type="CharacterBody2D" node_paths=PackedStringArray("playerInteract", "weaponManager")]
 position = Vector2(1, 1)
 script = ExtResource("1_f3x4s")
 playerInteract = NodePath("InteractArea")
+weaponManager = NodePath("WeaponManager")
 metadata/_edit_group_ = true
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
@@ -36,6 +36,7 @@ zoom = Vector2(1.5, 1.5)
 script = ExtResource("3_kj26r")
 
 [node name="WeaponManager" type="Node2D" parent="."]
+visible = false
 script = ExtResource("4_tfpqi")
 
 [node name="WeaponSprites" type="Node2D" parent="WeaponManager"]
@@ -55,8 +56,14 @@ shape = SubResource("RectangleShape2D_oerxt")
 [node name="Sprite2D" type="Sprite2D" parent="WeaponManager/Area2D/CollisionShape2D"]
 texture = ExtResource("6_ur58i")
 
+[node name="HitboxTimer" type="Timer" parent="WeaponManager"]
+process_callback = 0
+wait_time = 0.25
+
 [node name="InteractArea" parent="." instance=ExtResource("7_uvfh6")]
 script = ExtResource("8_c5q5l")
 
 [node name="InteractCS2D" type="CollisionShape2D" parent="InteractArea"]
 shape = SubResource("RectangleShape2D_jjc8b")
+
+[connection signal="timeout" from="WeaponManager/HitboxTimer" to="WeaponManager" method="OnHitboxTimerTimeout"]

--- a/Scripts/Interactions/CharacterInteractArea.cs
+++ b/Scripts/Interactions/CharacterInteractArea.cs
@@ -3,10 +3,29 @@ using System;
 
 public partial class CharacterInteractArea : InteractArea
 {
-	//This override will be used to set the characters current weapon, I think.
-	public void InteractWith()
+	public override int InteractWith()
 	{
-		GD.Print("Character interacts with area");
-		base.InteractWith();
+		int interactID;
+		if (curInteraction != null) {
+			GD.Print("Character interacts with area");
+			interactID = curInteraction.InteractedBy();
+			curInteraction.FreeParent();
+			GD.Print("Picked up object of itemID" + interactID);
+			return interactID;
+		}
+		GD.Print("No object to pickup in range");
+		return 0;
 	}
+	
+	public override void AreaEntered(Area2D area)
+	{
+		GD.Print("CharacterInArea");
+		curInteraction = (InteractArea) area;
+	}
+	
+	public override void AreaExited(Area2D area)
+	{
+		if (curInteraction == area) curInteraction = null;
+	}
+	public override void FreeParent() {GD.Print("This function should literally never be called, how did you call it");}
 }

--- a/Scripts/Interactions/InteractArea.cs
+++ b/Scripts/Interactions/InteractArea.cs
@@ -6,27 +6,33 @@ public partial class InteractArea : Area2D
 	public InteractArea curInteraction;
 	
 	//When another InteractArea enters this interact area, save it in field
-	public void AreaEntered(Area2D area)
+	public virtual void AreaEntered(Area2D area)
 	{
 		curInteraction = (InteractArea) area;
 	}
 
 	//When that same interactarea exits this interactarea, clear the field
-	public void AreaExited(Area2D area)
+	public virtual void AreaExited(Area2D area)
 	{
 		if (curInteraction == area) curInteraction = null;
 	}
 	
 	//This is a function that will be called when a player wants to interact with another object
-	public void InteractWith()
+	public virtual int InteractWith()
 	{
 		if (curInteraction != null) curInteraction.InteractedBy();
+		return 0;
 	}
 	
 	//This is the function that will be called when something ELSE interacts with this interact area
-	public void InteractedBy()
+	public virtual int InteractedBy()
 	{
 		GD.Print("This object has been interacted by some other object");
+		return 0;
+	}
+	
+	public virtual void FreeParent() {
+		GD.Print("InteractArea Freed, please override method");
 	}
 }
 

--- a/Scripts/Interactions/ObjectInteractArea.cs
+++ b/Scripts/Interactions/ObjectInteractArea.cs
@@ -3,9 +3,39 @@ using System;
 
 public partial class ObjectInteractArea : InteractArea
 {
-	//This override will be used to remove the object when it is interacted with
-	new public void InteractBy(){
-		GD.Print("Object picked up");
-		//remove object
+	[Export]
+	private Node2D parentObject;
+	
+	[Export]
+	private int itemID = 1;
+	
+	private Label pickupLabel;
+	
+	public override void _Ready(){
+		pickupLabel = GetNode<Label>("pickupLabel");
+		//Look into settings for what key is designated as interact key
+		//set the pickUp label's text to reflect this.
+		pickupLabel.Hide();
 	}
+	
+	//This override will be used to remove the object when it is interacted with
+	public override int InteractedBy(){
+		GD.Print("This item has been picked up");
+		return itemID;
+	}
+	
+	public override void AreaEntered(Area2D area)
+	{
+		GD.Print("ObjectWithinRange");
+		curInteraction = (InteractArea) area;
+		pickupLabel.Show();
+	}
+	
+	public override void AreaExited(Area2D area)
+	{
+		if (curInteraction == area) curInteraction = null;
+		pickupLabel.Hide();
+	}
+	
+	public override void FreeParent(){ parentObject.QueueFree();}
 }

--- a/Scripts/WeaponManager.cs
+++ b/Scripts/WeaponManager.cs
@@ -7,12 +7,14 @@ public partial class WeaponManager : Node2D
 	Godot.Area2D Hitbox;
 	Godot.Node2D WeaponSprite;
 	Godot.Viewport Viewport;
+	Godot.Timer HitboxTimer;
 	
 	public override void _Ready()
 	{
 		Hitbox = GetNode<Godot.Area2D>("Area2D"); //Used to draw the hitbox when clicked
 		WeaponSprite = GetNode<Godot.Node2D>("WeaponSprites"); //Used to rotate weapon sprite
 		Viewport = GetViewport(); //Used to get the screen width for drawing sword sprite
+		HitboxTimer = GetNode<Godot.Timer>("HitboxTimer");
 	}
 	
 	public override void _Process(double delta){
@@ -43,7 +45,16 @@ public partial class WeaponManager : Node2D
 		if (@event is InputEventMouseButton mouseEvent && @event.IsPressed())
 		{
 			LookAt(GetGlobalMousePosition());
+			HitboxTimer.Start();
 			Hitbox.Show();
 		}
 	}
+	
+	private void OnHitboxTimerTimeout()
+	{
+		Hitbox.Hide();
+	}
 }
+
+
+

--- a/Scripts/controlled1.cs
+++ b/Scripts/controlled1.cs
@@ -39,6 +39,9 @@ public partial class controlled1 : CharacterBody2D
 	[Export]
 	private InteractArea playerInteract;
 	
+	[Export]
+	private Node2D weaponManager;
+	
 	//velocity is a shared variable
 	Vector2 velocity;
 	//placeholder
@@ -138,7 +141,10 @@ public partial class controlled1 : CharacterBody2D
 	
 	public override void _UnhandledInput(InputEvent @event){
 		if (Input.IsActionJustPressed("interact")){
-			playerInteract.InteractWith();
+			int objectID = playerInteract.InteractWith();
+			//use objectID to get weapon sprite & attack animation sprite
+			if (objectID != 0) 
+				weaponManager.Show();
 		}
 	}
 }


### PR DESCRIPTION
Now you can pick up weapons with the interact key. Walk over to the sword and press E to pick it up.

Not only that, but now when you swing the sword, the swing's hitbox only lasts for a quarter of a second (up to be changed).