### PR TITLE
Add Timerbar to display when dash functionality is available.

### DIFF
--- a/Scenes/TimerBar.cs
+++ b/Scenes/TimerBar.cs
@@ -1,0 +1,57 @@
+using Godot;
+using System;
+
+public partial class TimerBar : Line2D
+{
+	
+	private Vector2 point1 = new Vector2(0f,0f);
+	private Vector2 point2;
+	private float bar = 33.0f;
+	
+	
+	//set starting values for an instance of the TimerBar
+	public void startFunc(float x, float y){
+		point2 = new Vector2(x,y);
+		//line point 1 is 0,0 to start at its default position of placement on the map
+		this.AddPoint(point1);
+		//line point 2 is adjustable in length, set y as 0 for horizontal bar.
+		this.AddPoint(point2);
+	}
+	
+	
+	//updates the bar with a value assumed to be positive
+	//Behavior of bar can be strange when adjusted by a negative value
+	//used primarily by dashFunc and dashBarTimer in order to have
+	//a visual indication of when the player can dash again.
+	public void updateBar(float adjustBy, int addorsub){
+		//change bar value by amount
+		if (addorsub==1){
+			bar = bar + adjustBy;
+		}
+		else{
+			bar = bar - adjustBy;
+		}
+		//set new bar position
+		SetPointPosition(1,new Vector2(bar,0f));
+		
+	}
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready()
+	{
+		/* Example starting values. Can be called from here if the object is indpendent
+		or from the startFunc method
+		AddPoint(point1);
+		AddPoint(point2);
+		GD.Print(GetPointPosition(1).X);
+		*/
+		
+	}
+
+	// Called every frame. 'delta' is the elapsed time since the previous frame.
+	public override void _Process(double delta)
+	{
+		//for timer bars where they update every frame.
+		//SetPointPosition(1,new Vector2(bar,0f));
+		
+	}
+}

--- a/Scenes/controlled1.tscn
+++ b/Scenes/controlled1.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=10 format=3 uid="uid://m038w8sqj84p"]
+[gd_scene load_steps=11 format=3 uid="uid://m038w8sqj84p"]
 
 [ext_resource type="Script" path="res://Scripts/controlled1.cs" id="1_f3x4s"]
 [ext_resource type="Texture2D" uid="uid://n78ldru40qme" path="res://Textures/Filler Character Image.png" id="1_swj3o"]
 [ext_resource type="Script" path="res://Scripts/CameraController.cs" id="3_kj26r"]
 [ext_resource type="Script" path="res://Scripts/WeaponManager.cs" id="4_tfpqi"]
+[ext_resource type="Script" path="res://Scenes/TimerBar.cs" id="7_l4k3f"]
 [ext_resource type="PackedScene" uid="uid://k518oatcttrq" path="res://Scenes/Subscenes/Interactables/InteractArea.tscn" id="7_uvfh6"]
 [ext_resource type="Script" path="res://Scripts/Interactions/CharacterInteractArea.cs" id="8_c5q5l"]
 
@@ -70,5 +71,12 @@ script = ExtResource("8_c5q5l")
 
 [node name="InteractCS2D" type="CollisionShape2D" parent="InteractArea"]
 shape = SubResource("RectangleShape2D_jjc8b")
+
+[node name="TimerBar" type="Line2D" parent="."]
+position = Vector2(-15.6967, -22.035)
+closed = true
+width = 5.0
+default_color = Color(0.172549, 1, 1, 1)
+script = ExtResource("7_l4k3f")
 
 [connection signal="timeout" from="WeaponManager/HitboxTimer" to="WeaponManager" method="OnHitboxTimerTimeout"]

--- a/Scripts/controlled1.cs
+++ b/Scripts/controlled1.cs
@@ -44,6 +44,9 @@ public partial class controlled1 : CharacterBody2D
 	
 	private WeaponManager weaponManager;
 	
+	//this is the dashBar timer graphical interface
+	private TimerBar myTimer;
+	
 	private int playerHealth = 100;
 	private int maxHealth = 100;
 	
@@ -61,7 +64,10 @@ public partial class controlled1 : CharacterBody2D
 		this.SetCollisionLayerValue(3,true);
 		weaponManager = GetNode<WeaponManager>("WeaponManager");
 		maxHealth = 100; //modifiers can be added here from skill tree
-		playerHealth = maxHealth; 
+		playerHealth = maxHealth;
+		//create a timerBar and initialize it with player pixel values.
+		myTimer = GetNode<TimerBar>("TimerBar");
+		myTimer.startFunc(33f,0f);
 	}
 	
 	//The way invulnerability works is that multiple types of invuln don't stack,
@@ -81,6 +87,7 @@ public partial class controlled1 : CharacterBody2D
 	//Dash recharge rate for overall dash recharge
 	public async Task dashBarTimer(){
 		await Task.Delay(TimeSpan.FromMilliseconds(dashLongCharge));
+		myTimer.updateBar(16.5f,1);
 		dashRecharge++;
 		return;
 	}
@@ -105,6 +112,7 @@ public partial class controlled1 : CharacterBody2D
 			velocity = (direction.Normalized() * 1000);
 			dashRecharge--;
 			invulnerability(dashLength);
+			myTimer.updateBar(16.5f,0);
 			dashInstanceTimer();
 			dashBarTimer();
 			

--- a/project.godot
+++ b/project.godot
@@ -17,10 +17,8 @@ config/icon="res://Textures/icon.png"
 
 [autoload]
 
-
 GlobalAnimation="*res://Scripts/sceneScripts/Animation.gd"
 Global="*res://Scripts/Global.gd"
-
 
 [debug]
 


### PR DESCRIPTION
Added a child node to the controlled1 scene that allows for the addition of  a line2D that functions as a timer. Used currently as the bar to display when the dash long recharge has finished.